### PR TITLE
Added and modified community standards

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,37 @@
+# Code of Conduct
+
+As contributors and maintainers of this project, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, or nationality.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people.
+- Being respectful of differing opinions, viewpoints, and experiences.
+- Giving and gracefully accepting constructive feedback.
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience.
+- Focusing on what is best not just for us as individuals, but for the overall community.
+- Having time to recognize the pattern of repository's issues management and ecosystem.
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery
+- Personal attacks
+- Trolling or insulting/derogatory comments
+- Public or private harassment
+- Publishing others' private information, such as physical or electronic addresses, without explicit permission
+- Other unethical or unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned with this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+By adopting this Code of Conduct, project maintainers commit themselves to fairly and consistently applying these principles to every aspect of managing this project. Project maintainers who do not follow or enforce the Code of Conduct may be permanently removed from the project team.
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [insert contact email or other contact information]. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Thank you for contributing to this project by abiding by these guidelines.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,13 @@ Please follow these guidelines when contributing to this repository:
 - If your changes require new dependencies or modify existing ones, please update the `relevant documentation`.
 - If your changes address any open issues or pull requests, please reference them in your commit message or pull request description.
 
+## Commit and Branch naming conventions:
+
+`DevOps Hobbies` open-source community is trying to increase the readability of commits, and for this goal, we are using Conventional Commits rules. If you are not familiar with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/), please check the link to learn more about them and consider using these rules for commit naming.
+
+Also for branch naming you can follow this convention:
+![Convention](https://miro.medium.com/max/640/1*bmeCQ9RKVpuLAqZHiVocxg.webp)
+
 ## Code of Conduct
 
 Please note that this project is released with a Contributor Code of Conduct. By participating in this project, you agree to abide by its terms. The code of conduct can be found in the [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) file.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing Guidelines
+
+Thank you for considering contributing to this repository! The following guidelines should help you get started with your contribution.
+
+## How to find the first task?
+
+- Look for issues. Issues can be a great start. Find suggestions that are approved, bugs that are reported or ..., to pick your very first task. Also, you can answer unanswered issues and it will be counted as a contribution.
+- Read the source code including documentation. If you find something wrong or a place for improvement! there you go, you have it.
+
+## Contributing
+
+Before contributing, please ensure that you have read and agree to the code of conduct.
+
+To contribute, please follow these steps:
+
+- Fork this repository.
+- Clone your forked repository to your local machine.
+- Create a new branch from the main branch.
+- Add or modify code base as needed, ensuring that they follow best practices and adhere to any language or environment-specific requirements.
+- Test your codes to ensure that they work as expected.
+- Update the README.md file with any relevant information about your changes.
+- Commit your changes and push them to your forked repository.
+- Open a pull request to the main branch of this repository and add a summary of changes on it.
+
+## Guidelines
+
+Please follow these guidelines when contributing to this repository:
+
+- Use clear and concise commit messages that describe the changes you have made.
+- Ensure that your code adheres to the coding standards and conventions used in this repository.
+- Test your code thoroughly to ensure that it works as expected.
+- Include any relevant documentation with your code changes.
+- If your changes require new dependencies or modify existing ones, please update the `relevant documentation`.
+- If your changes address any open issues or pull requests, please reference them in your commit message or pull request description.
+
+## Code of Conduct
+
+Please note that this project is released with a Contributor Code of Conduct. By participating in this project, you agree to abide by its terms. The code of conduct can be found in the [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) file.


### PR DESCRIPTION
# Changes:
- Added `CONTRIBUTING.md` file.
- Added `CODE_OF_CONDUCT.md` file.
- Added `conventional naming section` to the `CONTRIBUTING.md` file due to [this](https://github.com/devopshobbies/community-standards-template/blob/main/rules.md) file.
